### PR TITLE
Remove imlib2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Format:
 Orphan packages are those with `INACTIVE` maintainers (abandoned) to be forked / moved ownership to / adopted / supported by someone else.
 * [luaLZO](https://github.com/starius/luaLZO): GPL
 * [lamqp](https://github.com/daurnimator/lamqp): MIT
-* [imlib2](https://github.com/asb/lua-imlib2): MIT, unmaintained with [a](https://github.com/wezm/lua-imlib2) [few](https://github.com/agladysh/lua-imlib2) [forks](https://github.com/blackawps/lua-imlib2)
 * [ltcltk](https://github.com/stevedonovan/luabuild/tree/master/modules/ltcltk-0.9-2): MIT
 * [luacairo](http://www.dynaset.org/dogusanh/luacairo): MIT
 * [lqt](https://github.com/mkottman/lqt): MIT


### PR DESCRIPTION
imlib2 is considered legacy in EFL and has been replaced by features in
canvas. Other alternatives like imagemagick are better maintained. After
discussing this with an EFL project member he says having bindings for
imlib2 isn't all that useful.
