### PR TITLE
Add alt-getopt to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Orphan packages are those with `INACTIVE` maintainers (abandoned) to be forked /
 * [ltcltk](https://github.com/stevedonovan/luabuild/tree/master/modules/ltcltk-0.9-2): MIT
 * [luacairo](http://www.dynaset.org/dogusanh/luacairo): MIT
 * [lqt](https://github.com/mkottman/lqt): MIT
+* [alt-getopt](http://luaforge.net/projects/alt-getopt/): MIT
 
 
 


### PR DESCRIPTION
The only version listed on this website only supports what was at the time called "Lua 5"; fixing this would help with MoonScript while @leafo removes the library entirely.
